### PR TITLE
fix: replace 3 bare except clauses with except Exception

### DIFF
--- a/benchmarks/gpu_benchmark_modal.py
+++ b/benchmarks/gpu_benchmark_modal.py
@@ -50,7 +50,7 @@ def gpu_simulated_annealing(
     # Get GPU info
     try:
         gpu_info = subprocess.check_output(['nvidia-smi', '--query-gpu=name', '--format=csv,noheader'], text=True).strip()
-    except:
+    except Exception:
         gpu_info = "T4"
     
     start_time = time.time()

--- a/shared/block_synchronizer.py
+++ b/shared/block_synchronizer.py
@@ -99,7 +99,7 @@ class BlockSynchronizer:
             for _ in range(num_producers):
                 try:
                     download_queue.put(None)  # Sentinel value to stop producers
-                except:
+                except Exception:
                     pass  # Queue might be full or closed
                     
             for p in producer_processes:

--- a/tools/find_block_time_threshold.py
+++ b/tools/find_block_time_threshold.py
@@ -128,7 +128,7 @@ def test_mining_time(
                 elapsed = time.time() - start_time
                 try:
                     result = result_queue.get_nowait()
-                except:
+                except Exception:
                     result = None
         else:
             # No timeout - run directly


### PR DESCRIPTION
## What
Replace 3 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.