### PR TITLE
Split miner/coordinator stream reads from writes

### DIFF
--- a/crates/quip-coordinator/src/drive/harness.rs
+++ b/crates/quip-coordinator/src/drive/harness.rs
@@ -289,6 +289,11 @@ async fn handshake(
     Some(configure)
 }
 
+/// Depth of the read loop's queue of credit grants to the dispatcher task.
+/// Grants are single `u32`s, so this only has to absorb a burst of
+/// `JobRequest`s arriving while the dispatcher is mid-send.
+const GRANT_CHANNEL_DEPTH: usize = 1024;
+
 /// Grant `credits` and dispatch every staged job the router allows.
 /// Returns `false` when the outbound channel is closed (session should end).
 async fn dispatch_jobs(
@@ -395,18 +400,25 @@ async fn handle_fatal(state: &Arc<Mutex<CoordinatorState>>, run: &Arc<RunState>)
 async fn handle_message(
     msg: MinerMsg,
     state: &Arc<Mutex<CoordinatorState>>,
-    miner_id: &str,
+    _miner_id: &str,
     tx: &mpsc::Sender<Result<CoordMsg, Status>>,
     run: &Arc<RunState>,
+    grants: &mpsc::Sender<u32>,
     seed_credits: u32,
 ) -> bool {
     match msg.msg {
-        Some(miner_msg::Msg::Ready(_)) => {
-            dispatch_jobs(state, miner_id, seed_credits, tx, run).await
-        }
-        Some(miner_msg::Msg::JobRequest(req)) => {
-            dispatch_jobs(state, miner_id, req.credits, tx, run).await
-        }
+        // Seed credits from Configure so the first job can dispatch before the
+        // miner sends JobRequest: quip-mock-miner only requests after
+        // completing a job. This makes the pool exceed the miner's stated depth
+        // by `queue_depth` — harmless now that neither side couples reads to
+        // writes, but see the note in MINER_PROTOCOL.md about making the miner
+        // the sole credit source once every backend sends an initial request.
+        Some(miner_msg::Msg::Ready(_)) => grants.send(seed_credits).await.is_ok(),
+        // Hand the grant to the dispatcher task rather than dispatching here:
+        // sending jobs blocks once the outbound channel fills, and this is the
+        // only task reading results. Blocking here stops us reading the very
+        // results that would free credits — the deadlock this split fixes.
+        Some(miner_msg::Msg::JobRequest(req)) => grants.send(req.credits).await.is_ok(),
         Some(miner_msg::Msg::Result(result)) => {
             // Validate concurrently so the session task keeps draining the
             // stream and dispatching replacement jobs instead of blocking
@@ -454,11 +466,29 @@ async fn run_drive_session(
         return;
     }
     let seed_credits = configure.queue_depth.max(1);
+    // Dispatcher task: the only place that writes `Job`s. Kept off the read
+    // path so a full outbound channel can never stop us draining results.
+    let (grants, mut grant_rx) = mpsc::channel::<u32>(GRANT_CHANNEL_DEPTH);
+    let dispatcher = {
+        let state = Arc::clone(&state);
+        let run = Arc::clone(&run);
+        let tx = tx.clone();
+        let miner_id = miner_id.clone();
+        tokio::spawn(async move {
+            while let Some(credits) = grant_rx.recv().await {
+                if !dispatch_jobs(&state, &miner_id, credits, &tx, &run).await {
+                    return;
+                }
+            }
+        })
+    };
+
     loop {
         let Ok(Some(msg)) = inbound.message().await else {
             break;
         };
-        let keep_going = handle_message(msg, &state, &miner_id, tx, &run, seed_credits).await;
+        let keep_going =
+            handle_message(msg, &state, &miner_id, tx, &run, &grants, seed_credits).await;
         if !keep_going {
             break;
         }
@@ -467,6 +497,8 @@ async fn run_drive_session(
             break;
         }
     }
+    drop(grants);
+    dispatcher.abort();
 }
 
 /// Full drive-many run: spawn the miner over UDS, stage every job, validate

--- a/crates/quip-coordinator/src/session.rs
+++ b/crates/quip-coordinator/src/session.rs
@@ -19,6 +19,43 @@ use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 
+/// Depth of the read loop's queue of credit grants to the dispatcher task.
+/// Grants are single `u32`s, so this only absorbs a burst of `JobRequest`s
+/// arriving while the dispatcher is mid-send.
+const GRANT_CHANNEL_DEPTH: usize = 1024;
+
+/// Grant `credits` and send every job the miner is now entitled to.
+///
+/// Jobs are collected under the state lock and sent after releasing it: the
+/// lock guards coordinator-wide state, so holding it across a `tx.send().await`
+/// blocks every *other* miner's session for as long as this one's outbound
+/// channel stays full.
+///
+/// Returns `false` when the outbound channel is closed (session is over).
+async fn dispatch_granted(
+    state: &Arc<Mutex<CoordinatorState>>,
+    miner_id: &str,
+    credits: u32,
+    tx: &mpsc::Sender<Result<CoordMsg, Status>>,
+) -> bool {
+    let jobs = {
+        let mut st = state.lock().await;
+        st.router.grant_credits(miner_id, credits);
+        let mut jobs = Vec::new();
+        while let Some(job) = st.router.next_job(miner_id) {
+            st.dispatch_inflight(miner_id, job.clone());
+            jobs.push(job);
+        }
+        jobs
+    };
+    for job in jobs {
+        if tx.send(Ok(coord(coord_msg::Msg::Job(job)))).await.is_err() {
+            return false;
+        }
+    }
+    true
+}
+
 /// Unguessable per-spawn session token (32 random bytes, hex-encoded).
 ///
 /// # Panics
@@ -338,7 +375,7 @@ async fn run_session<C: ChainClient>(
     {
         return;
     }
-    let seed_credits = configure.queue_depth.max(1);
+    let configure_queue_depth = configure.queue_depth;
     if tx
         .send(Ok(coord(coord_msg::Msg::Configure(configure))))
         .await
@@ -364,34 +401,46 @@ async fn run_session<C: ChainClient>(
     // in-band Shutdown/cancel while it runs; dropped when the loop exits.
     state.lock().await.register_outbound(&miner_id, tx.clone());
 
+    let seed_credits = configure_queue_depth.max(1);
+    // Dispatcher task: the only writer of `Job`s for this session.
+    //
+    // Job sends must not happen on the read path. `tx.send().await` blocks once
+    // the outbound channel fills, and this loop is the only reader of the
+    // miner's `Result`s — so blocking here stops us consuming the results that
+    // would free the miner's credits, while the miner (symmetrically blocked
+    // writing those results) stops reading jobs. Both peers park permanently.
+    let (grants, mut grant_rx) = mpsc::channel::<u32>(GRANT_CHANNEL_DEPTH);
+    let _dispatcher = {
+        let state = Arc::clone(&state);
+        let tx = tx.clone();
+        let miner_id = miner_id.clone();
+        tokio::spawn(async move {
+            while let Some(credits) = grant_rx.recv().await {
+                if !dispatch_granted(&state, &miner_id, credits, &tx).await {
+                    return;
+                }
+            }
+        })
+    };
+
     // 3. Message loop
     'session: loop {
         let Ok(Some(msg)) = inbound.message().await else {
             break;
         };
         match msg.msg {
+            // Seed credits from Configure so the first job can dispatch before
+            // the miner sends JobRequest (quip-mock-miner only requests after
+            // completing a job). Routed through the dispatcher like every other
+            // grant, so it never sends on the read path.
             Some(miner_msg::Msg::Ready(_)) => {
-                // Seed credits from Configure so the first job can dispatch
-                // before the miner sends JobRequest (mock-miner only requests
-                // after completing a job).
-                let credits = seed_credits;
-                let mut st = state.lock().await;
-                st.router.grant_credits(&miner_id, credits);
-                while let Some(job) = st.router.next_job(&miner_id) {
-                    st.dispatch_inflight(&miner_id, job.clone());
-                    if tx.send(Ok(coord(coord_msg::Msg::Job(job)))).await.is_err() {
-                        break 'session;
-                    }
+                if grants.send(seed_credits).await.is_err() {
+                    break 'session;
                 }
             }
             Some(miner_msg::Msg::JobRequest(req)) => {
-                let mut st = state.lock().await;
-                st.router.grant_credits(&miner_id, req.credits);
-                while let Some(job) = st.router.next_job(&miner_id) {
-                    st.dispatch_inflight(&miner_id, job.clone());
-                    if tx.send(Ok(coord(coord_msg::Msg::Job(job)))).await.is_err() {
-                        break 'session;
-                    }
+                if grants.send(req.credits).await.is_err() {
+                    break 'session;
                 }
             }
             Some(miner_msg::Msg::Result(result)) => {

--- a/crates/quip-coordinator/tests/drive.rs
+++ b/crates/quip-coordinator/tests/drive.rs
@@ -99,7 +99,13 @@ async fn drives_two_entry_list_end_to_end() {
     assert_eq!(agg.total_jobs, 2);
     assert_eq!(agg.passed, 2);
     assert_eq!(agg.rejected, 0);
-    // Real wall span was measured (jobs completed), so throughput is positive.
-    assert!(report.run_wall_ms > 0);
-    assert!(agg.throughput_per_s > 0.0);
+    // A 2-job run against the mock miner can finish inside a single millisecond
+    // now that job dispatch no longer shares the session's read path, and the
+    // span is only measured to whole milliseconds — so 0 here means "too fast
+    // to measure", not "nothing ran". The row assertions above already prove
+    // both jobs completed. (`aggregate` reports 0 jobs/s for a sub-ms span; that
+    // reporting floor predates this change and is not what this test covers.)
+    if report.run_wall_ms > 0 {
+        assert!(agg.throughput_per_s > 0.0);
+    }
 }

--- a/crates/quip-coordinator/tests/flow_control.rs
+++ b/crates/quip-coordinator/tests/flow_control.rs
@@ -1,0 +1,134 @@
+//! Regression: a deep credit pool must not deadlock the miner session.
+//!
+//! Both peers speak one bidi stream. If either one writes on the same task that
+//! reads, a full outbound channel stops it reading — and since each side's
+//! reads are what free the other side's writes, both park permanently. The
+//! trigger is simply enough bytes in flight: a large credit pool plus jobs
+//! carrying inline `h`/`J`.
+//!
+//! This reproduces it through the public drive path. Pre-fix (dispatch on the
+//! coordinator's read loop) the run hangs and this test trips its timeout;
+//! post-fix the dispatcher is a separate task, so results keep draining.
+
+#![expect(
+    clippy::expect_used,
+    reason = "helper builds mock miner outside #[test]"
+)]
+#![expect(clippy::unwrap_used, reason = "now_ms helper outside #[test]")]
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "test wall-clock millis fit u64"
+)]
+
+use quip_coordinator::config::LaunchEntry;
+use quip_coordinator::drive::{DriveManyParams, JobRow};
+use quip_proto::v1::{ising_problem, Configure, EdgeList, IsingProblem, Job, JobKind};
+use quip_protocol::wire::encode_i32_le;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Sibling `quip-mock-miner` binary (not same package → no `CARGO_BIN_EXE_*`).
+fn mock_miner() -> String {
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["build", "-p", "quip-mock-miner"])
+        .status()
+        .expect("build quip-mock-miner");
+    assert!(status.success(), "failed to build quip-mock-miner");
+    let mut p = std::env::current_exe().expect("test exe path");
+    let _ = p.pop();
+    let _ = p.pop();
+    p.push("quip-mock-miner");
+    p.to_string_lossy().into_owned()
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+/// Jobs shaped like production nonces: an Advantage2-sized ring (4577 nodes)
+/// carries ~73 KB of inline `h`/`J`/edges, so a 480-deep pool puts ~35 MB on
+/// the wire. Volume is the whole trigger — at 5 KB per job the transport
+/// buffers absorb the burst and the deadlock does not appear.
+fn ring_jobs(count: usize, nodes: usize) -> Vec<Job> {
+    let deadline = now_ms() + 3_600_000;
+    let h: Vec<i32> = (0..nodes).map(|i| if i % 2 == 0 { 1000 } else { -1000 }).collect();
+    let u: Vec<u32> = (0..nodes as u32).collect();
+    let v: Vec<u32> = (0..nodes as u32).map(|i| (i + 1) % nodes as u32).collect();
+    let j: Vec<i32> = vec![500; nodes];
+    (0..count)
+        .map(|n| Job {
+            job_id: format!("job-{n}").into_bytes(),
+            kind: JobKind::IsingSample as i32,
+            generation: 0,
+            deadline_ms: deadline,
+            ising: Some(IsingProblem {
+                graph: Some(ising_problem::Graph::Edges(EdgeList {
+                    u: u.clone(),
+                    v: v.clone(),
+                })),
+                h_milli_le32: encode_i32_le(&h),
+                j_milli_le32: encode_i32_le(&j),
+                num_reads: 1,
+                num_sweeps: 1,
+                anneal_time_us: 0,
+            }),
+            provenance: None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn deep_credit_pool_does_not_deadlock_the_session() {
+    let miner = mock_miner();
+    let jobs = ring_jobs(480, 4577);
+    let total = jobs.len();
+
+    let entry = LaunchEntry {
+        miner_id: "cpu-0".into(),
+        binary: miner.clone(),
+        configure: Configure {
+            // The lever: `seed_credits` is `queue_depth`, so this grants the
+            // whole pool up front and the coordinator dispatches every staged
+            // job in one uninterrupted burst — exactly the flood that used to
+            // wedge the read path.
+            queue_depth: 480,
+            idle_timeout_s: 30,
+            heartbeat_s: 15,
+            reconnect_window_s: 60,
+            backend_toml: String::new(),
+        },
+    };
+
+    let sock = format!("/tmp/quip-flow-control-{}.sock", std::process::id());
+    let run = quip_coordinator::drive::run_drive(DriveManyParams {
+        miner_bin: &miner,
+        sock_path: &sock,
+        miner_id: "cpu-0",
+        token: "flow-control-token",
+        entry: &entry,
+        topology: None,
+        target: None,
+        jobs,
+        utilization: None,
+        yielding: false,
+    });
+
+    // A generous bound: the mock miner answers instantly, so this only fires if
+    // the session wedged. Without the timeout a regression hangs the suite
+    // instead of failing it.
+    let report = tokio::time::timeout(Duration::from_secs(90), run)
+        .await
+        .expect("session deadlocked: no progress within 90s");
+
+    assert!(report.handshake_ok, "handshake failed");
+    assert_eq!(
+        report.rows.len(),
+        total,
+        "every job must reach a terminal outcome; got {} of {total}",
+        report.rows.len()
+    );
+    let rejected = report.rows.iter().filter(|r: &&JobRow| r.rejected).count();
+    assert_eq!(rejected, 0, "no job should be rejected by the mock miner");
+}

--- a/crates/quip-miner-core/src/session.rs
+++ b/crates/quip-miner-core/src/session.rs
@@ -15,7 +15,8 @@ use quip_proto::v1::{coord_msg, miner_msg, CoordMsg, JobKind, JobRequest, MinerM
 use quip_protocol::session::{build_hello, BackendCaps, ExitCode, SessionConfig, SessionError};
 use std::collections::HashMap;
 use std::process::ExitCode as StdExitCode;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -54,6 +55,19 @@ fn print_capabilities(id: &BackendIdentity) {
 /// Emit a miner progress line every N completed jobs (v0.2 `mine_work_item`
 /// parity).
 const PROGRESS_LOG_INTERVAL: u64 = 10;
+
+/// Depth of the read loop's queue to the outbound writer task.
+///
+/// Carries only control replies — `Ready`, `JobRequest`, `Status`, and
+/// prepare-time `Reject`s — which are small and, apart from a burst of rejects
+/// from a malformed job run, rare. Sized so the read loop never waits on it in
+/// practice while still bounding memory if the peer stops reading entirely.
+const CTRL_CHANNEL_DEPTH: usize = 256;
+
+/// `job_id` → the `(num_reads, num_sweeps)` resolved for it at prepare time,
+/// shared between the session's read loop (which inserts) and its outbound
+/// writer (which removes to build `SamplerMeta`).
+type PendingParams = Arc<StdMutex<HashMap<Vec<u8>, (u32, u32)>>>;
 
 #[expect(
     clippy::cast_precision_loss,
@@ -148,56 +162,115 @@ async fn run_session<S: Sampler>(
 
     let mut grace_ms: u64 = 5000;
     let mut num_sweeps = DEFAULT_NUM_SWEEPS;
-    let mut jobs_done: u64 = 0;
     let mut topology: Option<TopologyCache> = None;
     let mut target: Option<SessionTarget> = None;
     // job_id → (num_reads, num_sweeps) resolved at prepare, for the result meta.
-    let mut pending: HashMap<Vec<u8>, (u32, u32)> = HashMap::new();
-    // Progress logging (mirrors v0.2 mine_work_item's every-N-attempts line).
-    let session_start = std::time::Instant::now();
-    let mut best_energy_milli: i64 = i64::MAX;
+    // Shared: the read loop inserts at prepare, the writer task removes at
+    // finalize. The lock is never held across an await.
+    let pending: PendingParams = Arc::new(StdMutex::new(HashMap::new()));
+    // Published by the writer, read here for `Status.jobs_done`.
+    let jobs_done = Arc::new(AtomicU64::new(0));
 
-    loop {
-        tokio::select! {
-            biased;
-            // Drain completed results first so a busy sampler never backs up.
-            Some(sr) = res_rx.recv() => {
-                let (reads, sweeps) = pending.remove(&sr.job_id).unwrap_or((0, 0));
-                // A Cancelled job neither advances progress nor updates best
-                // energy; finalize_result just refunds its credit.
-                let completed = matches!(sr.outcome, StreamOutcome::Completed(_));
-                if let StreamOutcome::Completed(Ok(samples)) = &sr.outcome {
-                    if let Some(e) = samples.iter().map(|r| r.energy_milli).min() {
-                        best_energy_milli = best_energy_milli.min(e);
+    // Writer task: the SOLE owner of the outbound sender.
+    //
+    // Reading the inbound stream and writing to the outbound one must not live
+    // in the same task. A `tx.send().await` blocks once the outbound channel
+    // fills, which happens whenever the coordinator is slow to read — and if
+    // that await sits in the same loop as `inbound.message()`, the miner stops
+    // reading jobs precisely because it is busy returning results. The
+    // coordinator, symmetrically blocked writing jobs, then stops reading
+    // results, and both peers park forever. This was reproducible: a 480-credit
+    // grant (~89 MB of inline h/J in flight) deadlocked the session within
+    // three dispatches.
+    //
+    // So the read loop hands outbound traffic to this task and never awaits the
+    // wire itself. Results (large) arrive on `res_rx` straight from the sampler;
+    // control replies (small, rare) arrive on `ctrl_rx` from the read loop.
+    let (ctrl_tx, mut ctrl_rx) = mpsc::channel::<MinerMsg>(CTRL_CHANNEL_DEPTH);
+    let writer = {
+        let tx = tx.clone();
+        let pending = Arc::clone(&pending);
+        let jobs_done = Arc::clone(&jobs_done);
+        let backend = id.backend;
+        tokio::spawn(async move {
+            // Progress logging (mirrors v0.2 mine_work_item's every-N-attempts line).
+            let session_start = std::time::Instant::now();
+            let mut best_energy_milli: i64 = i64::MAX;
+            let mut done: u64 = 0;
+            loop {
+                tokio::select! {
+                    biased;
+                    // Drain completed results first so a busy sampler never backs up.
+                    Some(sr) = res_rx.recv() => {
+                        let (reads, sweeps) = {
+                            let mut p = match pending.lock() {
+                                Ok(p) => p,
+                                Err(poisoned) => poisoned.into_inner(),
+                            };
+                            p.remove(&sr.job_id).unwrap_or((0, 0))
+                        };
+                        // A Cancelled job neither advances progress nor updates
+                        // best energy; finalize_result just refunds its credit.
+                        let completed = matches!(sr.outcome, StreamOutcome::Completed(_));
+                        if let StreamOutcome::Completed(Ok(samples)) = &sr.outcome {
+                            if let Some(e) = samples.iter().map(|r| r.energy_milli).min() {
+                                best_energy_milli = best_energy_milli.min(e);
+                            }
+                        }
+                        for reply in finalize_result(sr, reads, sweeps, &mut done) {
+                            if tx.send(reply).await.is_err() {
+                                return;
+                            }
+                        }
+                        jobs_done.store(done, Ordering::Relaxed);
+                        if completed && done > 0 && done.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+                            log_progress(
+                                backend,
+                                done,
+                                session_start.elapsed(),
+                                reads,
+                                sweeps,
+                                best_energy_milli,
+                            );
+                        }
                     }
-                }
-                for reply in finalize_result(sr, reads, sweeps, &mut jobs_done) {
-                    tx.send(reply).await?;
-                }
-                if completed && jobs_done > 0 && jobs_done.is_multiple_of(PROGRESS_LOG_INTERVAL) {
-                    log_progress(
-                        id.backend,
-                        jobs_done,
-                        session_start.elapsed(),
-                        reads,
-                        sweeps,
-                        best_energy_milli,
-                    );
+                    ctrl = ctrl_rx.recv() => {
+                        match ctrl {
+                            Some(msg) => {
+                                if tx.send(msg).await.is_err() {
+                                    return;
+                                }
+                            }
+                            // Read loop is gone and the sampler has drained.
+                            None if res_rx.is_closed() => return,
+                            None => {}
+                        }
+                    }
+                    else => return,
                 }
             }
-            // No wall-clock idle timeout: a miner grinding a hard nonce for
-            // minutes-to-hours legitimately receives nothing from the
-            // coordinator meanwhile — it is busy, not dead. Liveness of a
-            // truly-gone peer surfaces here as a closed stream (`Ok(None)`) or
-            // a transport error (`Err`); dead-peer detection over the network
-            // belongs to HTTP/2 keepalive, not an application quiet-period.
-            msg = inbound.message() => {
-                let cm: CoordMsg = match msg {
-                    Ok(Some(cm)) => cm,
-                    Ok(None) => break,
-                    Err(status) => return Err(status.into()),
-                };
-                match cm.msg {
+        })
+    };
+
+    loop {
+        // Read loop: owns the inbound stream and nothing else. Every outbound
+        // message goes through `ctrl_tx` so this loop cannot be blocked by a
+        // slow or backed-up peer.
+        //
+        // No wall-clock idle timeout: a miner grinding a hard nonce for
+        // minutes-to-hours legitimately receives nothing from the
+        // coordinator meanwhile — it is busy, not dead. Liveness of a
+        // truly-gone peer surfaces here as a closed stream (`Ok(None)`) or
+        // a transport error (`Err`); dead-peer detection over the network
+        // belongs to HTTP/2 keepalive, not an application quiet-period.
+        let msg = inbound.message().await;
+        {
+            let cm: CoordMsg = match msg {
+                Ok(Some(cm)) => cm,
+                Ok(None) => break,
+                Err(status) => return Err(status.into()),
+            };
+            match cm.msg {
                     Some(coord_msg::Msg::Welcome(w)) => {
                         if w.protocol_version != 1 {
                             return Err(SessionError::BadWelcome(w.protocol_version).into());
@@ -210,7 +283,7 @@ async fn run_session<S: Sampler>(
                         sampler.apply_config(&c.backend_toml);
                         num_sweeps = num_sweeps_from_toml(&c.backend_toml);
                         let config = SessionConfig::from_configure(miner_id.into(), &c);
-                        tx.send(miner(miner_msg::Msg::Ready(Ready {}))).await?;
+                        ctrl_tx.send(miner(miner_msg::Msg::Ready(Ready {}))).await?;
                         // Request enough credits to keep the prefetch buffer
                         // full (active + next per lane), so the backend always
                         // has a NEXT slot to rotate into.
@@ -219,10 +292,18 @@ async fn run_session<S: Sampler>(
                             reason = "stream width / prefetch are small device-local counts well under u32::MAX"
                         )]
                         let depth = config.queue_depth.max(prefetch as u32);
-                        tx.send(miner(miner_msg::Msg::JobRequest(JobRequest {
-                            credits: depth,
-                        })))
-                        .await?;
+                        // INVARIANT: the granted pool must not exceed the job
+                        // channel's capacity (`cap`), or the read loop can block
+                        // on `job_tx.send` with jobs still arriving — the same
+                        // deadlock one layer down. `cap == prefetch` and
+                        // `depth <= prefetch` unless the coordinator's
+                        // `queue_depth` is larger, so clamp to `cap`.
+                        let depth = depth.min(u32::try_from(cap).unwrap_or(u32::MAX));
+                        ctrl_tx
+                            .send(miner(miner_msg::Msg::JobRequest(JobRequest {
+                                credits: depth,
+                            })))
+                            .await?;
                     }
                     Some(coord_msg::Msg::Topology(t)) => {
                         topology = Some(TopologyCache::from_proto(&t));
@@ -245,18 +326,25 @@ async fn run_session<S: Sampler>(
                                 // job, so ask for a replacement credit — same as
                                 // a completion — to keep the coordinator's
                                 // consume-on-dispatch pool from leaking a slot.
-                                tx.send(msg).await?;
-                                tx.send(miner(miner_msg::Msg::JobRequest(JobRequest {
-                                    credits: 1,
-                                })))
-                                .await?;
+                                ctrl_tx.send(msg).await?;
+                                ctrl_tx
+                                    .send(miner(miner_msg::Msg::JobRequest(JobRequest {
+                                        credits: 1,
+                                    })))
+                                    .await?;
                             }
                             Prepared::Sample {
                                 job,
                                 num_reads,
                                 num_sweeps: ns,
                             } => {
-                                let _ = pending.insert(job.job_id.clone(), (num_reads, ns));
+                                {
+                                    let mut p = match pending.lock() {
+                                        Ok(p) => p,
+                                        Err(poisoned) => poisoned.into_inner(),
+                                    };
+                                    let _ = p.insert(job.job_id.clone(), (num_reads, ns));
+                                }
                                 if job_tx.send(job).await.is_err() {
                                     break;
                                 }
@@ -269,11 +357,21 @@ async fn run_session<S: Sampler>(
                         // backends that override sample_stream) aborts the
                         // in-flight one at its next checkpoint.
                         cancel.cancel_through(c.max_generation);
-                        tx.send(status_msg(miner_id, jobs_done, sampler.utilization()))
+                        ctrl_tx
+                            .send(status_msg(
+                                miner_id,
+                                jobs_done.load(Ordering::Relaxed),
+                                sampler.utilization(),
+                            ))
                             .await?;
                     }
                     Some(coord_msg::Msg::Ping(_)) => {
-                        tx.send(status_msg(miner_id, jobs_done, sampler.utilization()))
+                        ctrl_tx
+                            .send(status_msg(
+                                miner_id,
+                                jobs_done.load(Ordering::Relaxed),
+                                sampler.utilization(),
+                            ))
                             .await?;
                     }
                     Some(coord_msg::Msg::Shutdown(s)) => {
@@ -287,17 +385,18 @@ async fn run_session<S: Sampler>(
                     None => {}
                 }
             }
-        }
     }
 
-    // Stop feeding, then drain in-flight results within the grace window.
+    // Stop feeding, then let the writer flush in-flight results within the
+    // grace window. Closing both of its inputs is what ends it: `job_tx` stops
+    // the sampler, which drops `res_tx`; `ctrl_tx` closes the control side.
+    // The writer drains whatever the sampler already produced before returning,
+    // so the drain that used to live here now happens there.
     drop(job_tx);
+    drop(ctrl_tx);
     let grace = Duration::from_millis(grace_ms);
-    while let Ok(Some(sr)) = tokio::time::timeout(grace, res_rx.recv()).await {
-        let (reads, sweeps) = pending.remove(&sr.job_id).unwrap_or((0, 0));
-        for reply in finalize_result(sr, reads, sweeps, &mut jobs_done) {
-            tx.send(reply).await?;
-        }
+    if tokio::time::timeout(grace, writer).await.is_err() {
+        tracing::warn!("outbound writer did not finish within the shutdown grace window");
     }
     // Surface sampler-worker panics: join Err is a panic payload, not a clean drain.
     if let Err(panic) = sampler_thread.join() {


### PR DESCRIPTION
## Problem

Both the miner and the coordinator drove their shared bidi stream from a single task that also wrote to it. `tx.send().await` blocks once the outbound channel fills, and that await sat in the same loop as `inbound.message()` — so each side stopped reading precisely when it was busy writing. Each side's reads are what free the other's writes, so both park permanently.

Reproduced with a Metal miner granting 480 credits (~89 MB of inline `h`/`J` in flight): 287 jobs dispatched to the GPU, 10 results returned, then a hard stall with both processes at 0% CPU. Thread sample of the wedged miner:

```
streaming::run_stream -> form_and_commit -> next_seed -> blocking_recv  (parked)
```

This is volume-triggered, not a timing race. It reproduces at any batch size whose credit grant puts enough bytes on the wire, and it is reachable by default: the grant is `stream_width * 2`, which scales with GPU core count. A 40-core M4 Max grants 320 credits today; an 80-core machine would grant 640 and hang on stock settings.

## Changes

**Miner** (`quip-miner-core/session.rs`) — an outbound writer task now solely owns the sender. The read loop hands it results (straight from the sampler) and control replies over a bounded queue, and never awaits the wire itself. `pending` becomes a shared map and `jobs_done` an atomic, since the two tasks now split that state.

**Coordinator** (`quip-coordinator/session.rs`, `drive/harness.rs`) — a dispatcher task now owns job sends on both the production and drive paths; the read loop only forwards credit grants. The production path additionally collects jobs under the state lock and releases it *before* sending: that lock is coordinator-wide, so holding it across a send stalled every other miner's session as well.

**Credit clamp** — the miner clamps its grant to its job-channel capacity, so a coordinator-seeded pool cannot exceed the depth the miner can actually buffer.

## Testing

`crates/quip-coordinator/tests/flow_control.rs` stages 480 Advantage2-sized jobs (~73 KB each) against a 480-deep pool. Verified it is a real regression test, not a tautology:

- pre-fix (coordinator dispatcher reverted): `FAILED — session deadlocked: no progress within 90s`
- post-fix: passes in 1.7 s

Full suite green across `quip-miner-core`, `quip-coordinator`, `quip-mock-coordinator`, `quip-mock-miner`. Clippy clean on the touched crates. (`quip-protocol-py` does not link in my environment — pyo3 needs a Python interpreter — which is pre-existing and unrelated.)

## Notes for review

- **Seed credits kept.** I first made `Ready` grant nothing, on the grounds that the protocol names the miner as the sole credit source. That starves `quip-mock-miner`, which only sends `JobRequest` after completing a job, and the drive e2e test caught it. Reverted; the seed is now routed through the dispatcher like any other grant. Making the miner authoritative needs every backend to send an initial request first — worth doing, but as its own change.
- **One assertion relaxed.** `drive.rs` asserted `run_wall_ms > 0`; a 2-job run now completes inside a millisecond and the span is measured in whole ms. Note that `aggregate` reports 0 jobs/s for any sub-ms span — a pre-existing reporting floor this change made reachable, left alone here.
- Not yet validated end-to-end against `quip-miner-metal`: that crate pins `shared-v0.3.0` and does not compile against this branch's newer `StreamOutcome`/`CancelGuard` API. Needs the tag bump.